### PR TITLE
Add StackLayout

### DIFF
--- a/core/src/main/scala/org/nspl/layouts.scala
+++ b/core/src/main/scala/org/nspl/layouts.scala
@@ -207,3 +207,11 @@ case class ColumnLayout(
       )
   }
 }
+
+/** A Layout which stacks elements on top of each other.*/
+case class StackLayout() extends Layout {
+  def apply[F: FC](s: Seq[Bounds]) = {
+    if (s.isEmpty) s
+    else LayoutHelper.alignToAnchors(Seq(s), 0 fts, 0 fts, false, false)
+  }
+}


### PR DESCRIPTION
Hi!
I was working on a small project for university, this library came to me as the only plotting library built for Scala 3. Thanks!
I couldn't find a way to stack two graphs, however, and this is something I needed. So I dig through the code and crafted a layout that can do exactly what I wanted it to do. Since it's useful for me, maybe it will be useful for others and the project altogether.

By no means do I know if this is the best solution, but it works. It could maybe be used as a basis for proper graph stacking later.

This code:
```scala
val plot1 = rasterplot(data1)(par
  .xWidth(width)
  .yHeight(height)
  .xNumTicks(0)
  .yNumTicks(0)
  .xNoTickLabel(true)
  .yNoTickLabel(true)
)
val plot2 = xyplot(data2 -> line(
  color = Color(32, 48, 64),
  stroke = StrokeConf(.25.fts)
))(par
  .xWidth(width)
  .yHeight(height)
  .withXLim(Some(-0.5, data(0).length - 0.5))
  .withYLim(Some(-0.5, data.length - 0.5))
)

val plot = group(plot1, plot2, StackLayout())
```
produces this result:
![Screenshot From 2025-04-04 14-38-39](https://github.com/user-attachments/assets/c4eb580c-3aa6-41f2-aea5-f2099dadea42)